### PR TITLE
Packaging fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 matplotlib==3.1.2
 numpy==1.18.1
 torch==1.4.0
+tqdm==4.43.0

--- a/scinet/__init__.py
+++ b/scinet/__init__.py
@@ -1,0 +1,6 @@
+'''
+Scinet package, contains Scinet class and Hyperparameters class
+'''
+
+from .scinet import Scinet
+from .hyperparameters import Hyperparameters

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 # Package information
 NAME = 'SciNet'
-VERSION = "0.0.1"
+VERSION = "0.0.2"
 
 DESCRIPTION = 'PHYS490 Final Project - SciNet recreation'
 with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
@@ -19,7 +19,9 @@ CONTACT_EMAIL = 'nmdickso@edu.uwaterloo.ca'
 
 # Installation information
 # TODO should actually read this from requirements.txt
-REQUIRED = ['numpy', 'torch', 'matplotlib']
+with open(os.path.join(here, 'requirements.txt')) as f:
+    REQUIRED = f.read().splitlines()
+
 REQUIRES_PYTHON = '>=3.7'
 
 # setup parameters


### PR DESCRIPTION
Adds a quick fix to make the whole packaging thing a bit easier to use. Probably not the final product of packaging fixes, we may want to rearrange a bit in the future, but this is enough to get us working.

It all worked before, it was just very tedious as using the actual `Scinet` class required something like:

```
import scinet

params = scinet.hyperparameters.Hyperparameters()
model = scinet.scinet.Scinet(params)
```

Which is just tedious, I don't want to type the same word three times in a row. Now the `Scinet` and `Hyperparameters` classes are in the top package "namespace":

```
import scinet

params = scinet.Hyperparameters()
model = scinet.Scinet(params)
```

As before, you can install the scinet package by going to the top directory (containing `setup.py`) and running `pip install -e ./` then just have at er like any normal package.