### PR TITLE
VAE updates - Round 2

### DIFF
--- a/scinet/hyperparameters.py
+++ b/scinet/hyperparameters.py
@@ -22,4 +22,4 @@ class Hyperparameters:
         self.learningRate = 0.001
 
         self.optimizer = optim.Adam
-        self.leadingLoss = 'BCE'
+        self.leadingLoss = nn.BCELoss

--- a/scinet/scinet.py
+++ b/scinet/scinet.py
@@ -65,14 +65,14 @@ class Scinet(nn.Module):
             std = torch.exp(sig.mul_(0.5))
             D_KL = 0.5 * (1 + torch.log(std.pow(2)) - mu.pow(2) - std.pow(2))
             return leading - D_KL.sum()
-        
+
         self.lossFunct = VAE_loss
 
     def encode(self, x):
         # Pass through encoder layers
         for layer in self.encoder:
             x = funct.relu(layer(x))
-        # Create mu and sig    
+        # Create mu and sig
         mu = self.fc_mu(x)
         sig = self.fc_sig(x)
         # Return them
@@ -102,7 +102,7 @@ class Scinet(nn.Module):
                 Z = funct.relu(Z)
         return Z
 
-    def forward(self, x, question, verbose=False):
+    def forward(self, x, question):
 
         # pass through encoder
         mu, sig = self.encode(x)
@@ -127,7 +127,7 @@ class Scinet(nn.Module):
             questionBatch = questions[i:i + batchSize].to(self.device)
 
             self.zero_grad()
-            mu, sig, Z, outputs = self(observationBatch, questionBatch, verbose=verbose)
+            mu, sig, Z, outputs = self(observationBatch, questionBatch)
             loss = self.lossFunct(mu, sig, outputs, answersBatch)
             loss.backward()
             self.optimizer.step()
@@ -154,7 +154,7 @@ class Scinet(nn.Module):
                 answersBatch = answers[i:i + batchSize].to(self.device)
                 questionBatch = questions[i:i + batchSize].to(self.device)
 
-                mu, sig, Z, outputs = self(observationBatch, questionBatch, verbose=verbose)
+                mu, sig, Z, outputs = self(observationBatch, questionBatch)
                 loss = self.lossFunct(mu, sig, outputs, answersBatch)
 
                 avgLoss += loss.item() * len(observationBatch)


### PR DESCRIPTION
So, the main thing is that for the (admittedly edge-case) `copernicus` RNN, the reparametrization is only done for the "first pass" of the network, during encoding, while the recurrent time evolution requires a simpler loss function.

So, rather than defining and working that all out myself in `copernicus`, I think it's much easier and cleaner to simply re-juggle the loss function initialization a tiny bit. I've walked back the changes to the `hyperparameters` and now the leading loss function is simply defined explicitly in there, then initialized and stored as `self.leadingLoss` in `__init__`, and then used in @keyblaede's VAE loss function. This way, when I don't need the full VAE loss, I can simply use the leading loss function instead.

I'll be honest, I never really understood changing the leading loss to a parsed string, it seemed a little convoluted. That's pretty much the only thing changed here, and it makes my life easier this way. If you've got a good reason against what I've done here, let me know and I can look at it again.